### PR TITLE
This fixes cl-webkit so that:

### DIFF
--- a/dom/cl-webkit-dom.asd
+++ b/dom/cl-webkit-dom.asd
@@ -29,4 +29,4 @@
                (:file "event")
                (:file "keyboard-event")
                (:file "mouse-event"))
-  :depends-on (:cffi :cl-cffi-gtk))
+  :depends-on (:cffi :cl-cffi-gtk :cl-cffi-gtk-gobject))

--- a/dom/package.lisp
+++ b/dom/package.lisp
@@ -12,4 +12,4 @@
 
 (defpackage #:cl-webkit-dom
   (:nicknames :webkit-dom)
-  (:use :cl :cffi))
+  (:use :cl :cffi :gobject))

--- a/webkit2/callback.lisp
+++ b/webkit2/callback.lisp
@@ -17,7 +17,7 @@
   `(cffi:defcallback ,name :void ((source-object :pointer)
                                   (result g-async-result)
                                   (user-data :pointer))
-                     `@body))
+                     ,@body))
 
 (defmacro with-g-async-ready-callback ((var &body callback-body) &body body)
   (let ((g (gensym "CALLBACK")))
@@ -26,4 +26,4 @@
            ,@callback-body)
        (let ((,var (callback ,g)))
          ,@body)
-       (fmakeunbound ,g))))
+       (fmakunbound ',g))))


### PR DESCRIPTION
- it also loads into CLISP
- the callback function and macros work