### PR TITLE
settings: add missing setting

### DIFF
--- a/webkit2/webkit2.settings.lisp
+++ b/webkit2/webkit2.settings.lisp
@@ -30,6 +30,7 @@
     ("enable-hyperlink-auditing" "gboolean" t t)
     ("enable-java" "gboolean" t t)
     ("enable-javascript" "gboolean" t t)
+    ("enable-javascript-markup" "gboolean" t t)
     ("enable-media-stream" "gboolean" t t)
     ("enable-mediasource" "gboolean" t t)
     ("enable-offline-web-application-cache" "gboolean" t t)


### PR DESCRIPTION
We still missed (at least) this setting. I tested it using next browser and it seems to work as advertised.