### PR TITLE
Add WebsiteData and WebsiteDataManager

### DIFF
--- a/demo/simple-browser.lisp
+++ b/demo/simple-browser.lisp
@@ -21,8 +21,13 @@
   "A single-window browser with no keyboard or mouse input.
 Loads and renders a single web page."
   (gtk:within-main-loop
-    (let ((win (make-instance 'gtk:gtk-window))
-          (view (make-instance 'webkit2:webkit-web-view)))
+    (let* ((win (make-instance 'gtk:gtk-window))
+           (manager (make-instance 'webkit:webkit-website-data-manager
+                                   :base-data-directory "testing-data-manager"))
+           (context (make-instance 'webkit:webkit-web-context
+                                   :website-data-manager manager))
+           (view (make-instance 'webkit2:webkit-web-view
+                                :web-context context)))
       (gobject:g-signal-connect win "destroy"
                                 #'(lambda (widget)
                                     (declare (ignore widget))

--- a/webkit2/cl-webkit2.asd
+++ b/webkit2/cl-webkit2.asd
@@ -59,6 +59,7 @@
                (:file "webkit2.web-context")
                (:file "webkit2.web-page")
                (:file "webkit2.web-resource")
+               (:file "webkit2.website-data-manager")
                (:file "webkit2.web-inspector")
                (:file "webkit2.web-view")
                (:file "webkit2.window-properties"))

--- a/webkit2/webkit2.web-context.lisp
+++ b/webkit2/webkit2.web-context.lisp
@@ -12,7 +12,8 @@
 
 (in-package #:webkit2)
 
-(define-webkit-class "WebKitWebContext" () ())
+(define-webkit-class "WebKitWebContext" ()
+    (("website-data-manager" "WebKitWebsiteDataManager" t t)))
 
 (define-g-enum "WebKitCacheModel" webkit-cache-model ()
   :webkit-cache-model-document-viewer
@@ -34,6 +35,14 @@
 
 (defcfun "webkit_web_context_get_default" (g-object webkit-web-context))
 (export 'webkit-web-context-get-default)
+
+(defcfun "webkit_web_context_new_with_website_data_manager" (g-object webkit-web-context)
+  (manager (g-object webkit-website-data-manager)))
+(export 'webkit-web-context-new-with-website-data-manager)
+
+(defcfun "webkit_web_context_get_website_data_manager" (g-object webkit-website-data-manager)
+  (context (g-object webkit-web-context)))
+(export 'webkit-web-context-get-website-data-manager)
 
 (defcfun "webkit_web_context_set_cache_model" :void
   (webkit-web-context (g-object webkit-web-context))
@@ -149,6 +158,7 @@
 (export 'webkit-web-context-prefetch-dns)
 
 (defcfun "webkit_web_context_set_disk_cache_directory" :void
+  "Deprecated since 2.10. Don't use it in a newly-written code!"
   (webkit-web-context (g-object webkit-web-context))
   (hostname :string))
 (export 'webkit-web-context-set-disk-cache-directory)

--- a/webkit2/webkit2.web-view.lisp
+++ b/webkit2/webkit2.web-view.lisp
@@ -82,6 +82,10 @@
 
 (defctype js-value-ref :pointer)
 
+(defcfun "webkit_web_view_get_website_data_manager" (g-object webkit-website-data-manager)
+  (web-view (g-object webkit-web-view)))
+(export 'webkit-web-view-get-website-data-manager)
+
 (defcfun "webkit_web_view_load_uri" :void
   (web-view (g-object webkit-web-view))
   (uri :string))

--- a/webkit2/webkit2.website-data-manager.lisp
+++ b/webkit2/webkit2.website-data-manager.lisp
@@ -1,0 +1,108 @@
+;;; webkit2.website-data-manager.lisp --- bindings for WebKitWebsiteDataManager
+
+;; This file is part of cl-webkit.
+;;
+;; cl-webkit is free software; you can redistribute it and/or modify
+;; it under the terms of the MIT license.
+;; See `COPYING' in the source distribution for details.
+
+;;; Code:
+
+(in-package #:webkit2)
+
+(define-webkit-class "WebKitWebsiteDataManager" ()
+    (("base-cache-directory" "gchararray")
+     ("base-data-directory" "gchararray")
+     ("disk-cache-directory" "gchararray")
+     ("hsts-cache-directory" "gchararray")
+     ("indexeddb-directory" "gchararray")
+     ("is-ephemeral" "gboolean")
+     ("local-storage-directory" "gchararray")
+     ("offline-application-cache-directory" "gchararray")))
+
+(defctype webkit-website-data :pointer) ; XXX: GBoxed struct WebKitWebsiteData
+
+(define-g-enum "WebKitWebsiteDataTypes" webkit-website-data-types ()
+  :webkit-website-data-memory-cache
+  :webkit-website-data-disk-cache
+  :webkit-website-data-offline-application-cache
+  :webkit-website-data-session-storage
+  :webkit-website-data-local-storage
+  :webkit-website-dataindexeddb-databases
+  :webkit-website-data-plugin-data
+  :webkit-website-data-cookies
+  :webkit-website-data-device-id-hash-salt ;; From 2.24
+  :webkit-website-data-hsts-cache          ;; From 2.26.
+  :webkit-website-data-all)
+
+(defcfun "webkit_website_data_ref" webkit-website-data
+  (website-data webkit-website-data))
+(export 'webkit-website-data-ref)
+
+(defcfun "webkit_website_data_unref" webkit-website-data
+  (website-data webkit-website-data))
+(export 'webkit-website-data-unref)
+
+(defcfun "webkit_website_data_get_name" :pointer ; XXX: const char *
+  (website-data webkit-website-data))
+(export 'webkit-website-data-get-name)
+
+(defcfun "webkit_website_data_get_types" webkit-website-data-types
+  (website-data webkit-website-data))
+(export 'webkit-website-data-get-types)
+
+(defcfun "webkit_website_data_get_size" :uint  ; guint64
+  (website-data webkit-website-data)
+  (types webkit-website-data-types))
+
+
+(defcfun "webkit_website_data_manager_new_ephemeral" (g-object webkit-website-data-manager))
+(export 'webkit-website-data-manager-new-ephemeral)
+
+(defcfun "webkit_website_data_manager_get_cookie_manager" (g-object webkit-cookie-manager)
+  (manager (g-object webkit-website-data-manager)))
+(export 'webkit-website-data-manager-get-cookie-manager)
+
+(defcfun "webkit_website_data_manager_fetch" :void
+  (manager (g-object webkit-website-data-manager))
+  (types webkit-website-data-types)
+  (cancellable :pointer) ; GCancellable
+  (callback g-async-ready-callback)
+  (user-data :pointer))
+(export 'webkit-website-data-manager-fetch)
+
+(defcfun "webkit_website_data_manager_fetch_finish" (glib:g-list webkit-website-data)
+  (manager (g-object webkit-website-data-manager))
+  (result g-async-result)
+  (error (:pointer (:struct glib:g-error))))
+(export 'webkit-website-data-manager-fetch-finish)
+
+(defcfun "webkit_website_data_manager_remove" :void
+  (manager (g-object webkit-website-data-manager))
+  (types webkit-website-data-types)
+  (website-data (glib:g-list webkit-website-data))
+  (cancellable :pointer) ; GCancellable
+  (callback g-async-ready-callback)
+  (user-data :pointer))
+(export 'webkit-website-data-manager-remove)
+
+(defcfun "webkit_website_data_manager_remove_finish" :boolean
+  (manager (g-object webkit-website-data-manager))
+  (result g-async-result)
+  (error (:pointer (:struct glib:g-error))))
+(export 'webkit-website-data-manager-remove-finish)
+
+(defcfun "webkit_website_data_manager_clear" :void
+  (manager (g-object webkit-website-data-manager))
+  (types webkit-website-data-types)
+  (timespan :uint) ;GTimeSpan
+  (cancellable :pointer) ; GCancellable
+  (callback g-async-ready-callback)
+  (user-data :pointer))
+(export 'webkit-website-data-manager-clear)
+
+(defcfun "webkit_website_data_manager_clear_finish" :boolean
+  (manager (g-object webkit-website-data-manager))
+  (result g-async-result)
+  (error (:pointer (:struct glib:g-error))))
+(export 'webkit-website-data-manager-clear-finish)


### PR DESCRIPTION
This add two connected classes form WebKit 2.10+ -- `WebsiteData` and `WebsiteDataManager`. These classes can ge useful, given that they simplify the complicated storage management necessary for the modern Web to work.

#### How Has This Been Tested

- Code was compiled piece-by-piece and I've fixed all the warnings I've seen.
- `cl-webkit` system was built form altered Guix package definition and compiled without erreors/warnings. Here's the definition:
``` scheme
(use-modules (gnu)
             (gnu packages lisp-xyz)
             (gnu packages webkit)

             (guix build-system asdf)
             (guix git-download)
             (guix packages)
             ((guix licenses) #:prefix license:))

(define-public cl-webkit
  (let ((commit "0ca9d7e469d7a5c5b7ae27dad6a5c1257fe688c8"))
    (package
      (name "cl-webkit")
      (version (git-version "2.4" "3" commit))
      (source
       (origin
         (method git-fetch)
         (uri (git-reference
               (url "https://github.com/aartaka/cl-webkit")
               (commit commit)))
         (file-name (git-file-name "cl-webkit" version))
         (sha256
          (base32
           "123cwnj7c3fbmc0yk1rwa6ka4x75i6p8y8hbrpd3hnrf88w35gax"))))
      (build-system asdf-build-system/sbcl)
      (inputs
       `(("cffi" ,sbcl-cffi)
         ("cl-cffi-gtk" ,sbcl-cl-cffi-gtk)
         ("webkitgtk" ,webkitgtk)))
      (arguments
       `(#:asd-file "webkit2/cl-webkit2.asd"
         #:asd-system-name "cl-webkit2"
         #:phases
         (modify-phases %standard-phases
           (add-after 'unpack 'fix-paths
             (lambda* (#:key inputs #:allow-other-keys)
               (substitute* "webkit2/webkit2.init.lisp"
                 (("libwebkit2gtk" all)
                  (string-append
                   (assoc-ref inputs "webkitgtk") "/lib/" all))))))))
      (home-page "https://github.com/joachifm/cl-webkit")
      (synopsis "Binding to WebKitGTK+ for Common Lisp")
      (description
       "@command{cl-webkit} is a binding to WebKitGTK+ for Common Lisp,
currently targeting WebKit version 2.  The WebKitGTK+ library adds web
browsing capabilities to an application, leveraging the full power of the
WebKit browsing engine.")
      (license license:expat))))

cl-webkit
```
- These objects are tied to the runtime and testing them in a demo provided with the `cl-webkit` seemed inadequate, so I took the idea "it compiles means it works" as a satisfactory testing mechanism in this case :)

I'll be glad to know what you think of it!