### PR TITLE
Add is-ephemeral property

### DIFF
--- a/demo/simple-browser.lisp
+++ b/demo/simple-browser.lisp
@@ -31,6 +31,22 @@ Loads and renders a single web page."
       (webkit2:webkit-web-view-load-uri view "http://www.example.com")
       (gtk:gtk-widget-show-all win))))
 
-(defun do-simple-browser-main ()
-  (simple-browser-main)
+(defun private-browser-main ()
+  "An ephemeral (a.k.a private) mode version of `simple-browser-main'."
+  (gtk:within-main-loop
+   (let* ((win (make-instance 'gtk:gtk-window))
+          (context (webkit:webkit-web-context-new-ephemeral))
+          (view (make-instance 'webkit2:webkit-web-view :web-context context)))
+     (gobject:g-signal-connect win "destroy"
+                               #'(lambda (widget)
+                                   (declare (ignore widget))
+                                   (gtk:leave-gtk-main)))
+     (gtk:gtk-container-add win view)
+     (webkit2:webkit-web-view-load-uri view "http://www.example.com")
+     (gtk:gtk-widget-show-all win))))
+
+(defun do-simple-browser-main (&key (private nil))
+  (if private
+      (private-browser-main)
+      (simple-browser-main))
   (gtk:join-gtk-main))

--- a/webkit2/webkit2.settings.lisp
+++ b/webkit2/webkit2.settings.lisp
@@ -36,7 +36,7 @@
     ("enable-offline-web-application-cache" "gboolean" t t)
     ("enable-page-cache" "gboolean" t t)
     ("enable-plugins" "gboolean" t t)
-    ("enable-private-browsing" "gboolean" t t)
+    ("enable-private-browsing" "gboolean" t t) ;; Deprecated since 2.16
     ("enable-resizable-text-areas" "gboolean" t t)
     ("enable-site-specific-quirks" "gboolean" t t)
     ("enable-smooth-scrolling" "gboolean" t t)

--- a/webkit2/webkit2.web-context.lisp
+++ b/webkit2/webkit2.web-context.lisp
@@ -35,6 +35,13 @@
 (defcfun "webkit_web_context_get_default" (g-object webkit-web-context))
 (export 'webkit-web-context-get-default)
 
+(defcfun "webkit_web_context_new_ephemeral" (g-object webkit-web-context))
+(export 'webkit-web-context-new-ephemeral)
+
+(defcfun "webkit_web_context_is_ephemeral" :boolean
+  (context (g-object webkit-web-context)))
+(export 'webkit-web-context-is-ephemeral)
+
 (defcfun "webkit_web_context_set_cache_model" :void
   (webkit-web-context (g-object webkit-web-context))
   (webkit-cache-model webkit-cache-model))

--- a/webkit2/webkit2.web-view.lisp
+++ b/webkit2/webkit2.web-view.lisp
@@ -33,6 +33,7 @@
   (:superclass gtk-widget
    :interfaces ("AtkImplementorIface" "GtkBuildable"))
   (("estimated-load-progress" "gdouble")
+   ("is-ephemeral" "gboolean")
    ("is-loading" "gboolean")
    ("title" "gchararray")
    ("uri" "gchararray")


### PR DESCRIPTION
This adds the `is-ephemeral` property of `webkit-web-view` that can be and should be (instead of the deprecated `enable-private-browsing` `WebKitSettings` property) used to implement private browsing mode. Given the importance of a private mode for a browser, this is a necessary change that makes cl-webkit more complete. Several `ephemeral`ity-related function on `webkit-web-context` are included too.

#### How Has This Been Tested:

- Library was compiled without errors.
- `simple-browser.lisp` testing file was edited according to the change (only the `simple-browser-main` function was altered):
``` lisp
(defun simple-browser-main ()
  "A single-window browser with no keyboard or mouse input.
Loads and renders a single web page."
  (gtk:within-main-loop
    (let* ((win (make-instance 'gtk:gtk-window))
          (context (webkit:webkit-web-context-new-ephemeral))
          (view (make-instance 'webkit2:webkit-web-view :web-context context)))
      (gobject:g-signal-connect win "destroy"
                                #'(lambda (widget)
                                    (declare (ignore widget))
                                    (gtk:leave-gtk-main)))
      (gtk:gtk-container-add win view)
      (webkit2:webkit-web-view-load-uri view "http://www.example.com")
      (gtk:gtk-widget-show-all win))))
```

And it ran without any problem.

I'll be glad to see you feedback on that!