### PR TITLE
WebKitWebExtension support

### DIFF
--- a/demo/test-extensions/Makefile
+++ b/demo/test-extensions/Makefile
@@ -1,0 +1,15 @@
+PKG_MODULES := gobject-2.0 webkit2gtk-web-extension-4.0
+
+CFLAGS += ${shell pkg-config ${PKG_MODULES} --cflags}
+LDLIBS += ${shell pkg-config ${PKG_MODULES} --libs}
+
+all: test-extension.so
+
+test-extension.so: test-extension.o
+	${LD} ${LDFLAGS} -fPIC -shared -o $@ $^ ${LDLIBS}
+
+test-extension.o:
+	${CC} -fPIC -o $@ -c ${CFLAGS} test-extension.c
+
+clean:
+	${RM} test-extension.so test-extension.o

--- a/demo/test-extensions/test-extension.c
+++ b/demo/test-extensions/test-extension.c
@@ -1,0 +1,19 @@
+#include <webkit2/webkit-web-extension.h>
+
+static void
+web_page_created_callback (WebKitWebExtension *extension,
+                           WebKitWebPage      *web_page,
+                           gpointer            user_data)
+{
+    g_print ("Page %lu created for %s\n",
+             webkit_web_page_get_id (web_page),
+             webkit_web_page_get_uri (web_page));
+}
+
+G_MODULE_EXPORT void
+webkit_web_extension_initialize (WebKitWebExtension *extension)
+{
+    g_signal_connect (extension, "page-created",
+                      G_CALLBACK (web_page_created_callback),
+                      NULL);
+}

--- a/webkit2/cl-webkit2.asd
+++ b/webkit2/cl-webkit2.asd
@@ -64,5 +64,6 @@
                (:file "webkit2.web-view")
                (:file "webkit2.window-properties")
                (:file "webkit2.uri-utilities")
-               (:file "webkit2.user-message"))
+               (:file "webkit2.user-message")
+               (:file "webkit2.web-extension"))
   :depends-on (:cffi :cl-cffi-gtk))

--- a/webkit2/cl-webkit2.asd
+++ b/webkit2/cl-webkit2.asd
@@ -63,5 +63,6 @@
                (:file "webkit2.web-inspector")
                (:file "webkit2.web-view")
                (:file "webkit2.window-properties")
-               (:file "webkit2.uri-utilities"))
+               (:file "webkit2.uri-utilities")
+               (:file "webkit2.user-message"))
   :depends-on (:cffi :cl-cffi-gtk))

--- a/webkit2/webkit2.user-message.lisp
+++ b/webkit2/webkit2.user-message.lisp
@@ -1,0 +1,49 @@
+;;; webkit2.user-message.lisp --- bindings for WebKitUserMessage
+
+;; This file is part of cl-webkit.
+;;
+;; cl-webkit is free software; you can redistribute it and/or modify
+;; it under the terms of the MIT license.
+;; See `COPYING' in the source distribution for details.
+
+;;; Code:
+
+(in-package #:webkit2)
+
+(define-webkit-class "WebKitUserMessage" ()
+  (("fd-list" "GUnixFDList")
+   ("name" "gchararray")
+   ("parameters" "GVariant")))
+
+(define-g-enum "WebKitUserMessageError" webkit-user-message-error ()
+  :webkit-user-message-unhandled-message)
+
+(defcfun "webkit_user_message_error_quark" glib:g-quark)
+
+(defcfun "webkit_user_message_new" (g-object webkit-user-message)
+  (name :pointer)  ; XXX: const char *
+  (parameters (:pointer (:struct glib:g-variant))))
+(export 'webkit-user-message-new)
+
+(defcfun "webkit_user_message_new_with_fd_list" (g-object webkit-user-message)
+  (name :pointer)  ; XXX: const char *
+  (parameters (:pointer (:struct glib:g-variant)))
+  (fd-list :pointer)) ; fd_list *
+(export 'webkit-user-message-new-with-fd-list)
+
+(defcfun "webkit_user_message_get_name" :pointer ; XXX: const char *
+  (message (g-object webkit-user-message)))
+(export 'webkit-user-message-get-name)
+
+(defcfun "webkit_user_message_get_parameters" (:pointer (:struct glib:g-variant)) ; GVariant *
+  (message (g-object webkit-user-message)))
+(export 'webkit-user-message-get-parameters)
+
+(defcfun "webkit_user_message_get_fd_list" :pointer ; GUnixFDList *
+  (message (g-object webkit-user-message)))
+(export 'webkit-user-message-get-fd-list)
+
+(defcfun "webkit_user_message_send_reply" :void
+  (message (g-object webkit-user-message))
+  (reply (g-object webkit-user-message)))
+(export 'webkit-user-message-send-reply)

--- a/webkit2/webkit2.web-extension.lisp
+++ b/webkit2/webkit2.web-extension.lisp
@@ -1,0 +1,32 @@
+;;; webkit2.web-extension.lisp --- bindings for WebKitWebExtension
+
+;; This file is part of cl-webkit.
+;;
+;; cl-webkit is free software; you can redistribute it and/or modify
+;; it under the terms of the MIT license.
+;; See `COPYING' in the source distribution for details.
+
+;;; Code:
+
+(in-package #:webkit2)
+
+(defctype webkit-web-extension :pointer)
+
+(defcfun "webkit_web_extension_get_page" (g-object webkit-web-page)
+  (extension webkit-web-extension)
+  (page-id :uint))
+(export 'webkit-web-extension-get-page)
+
+(defcfun "webkit_web_extension_send_message_to_context" :void
+  (extension webkit-web-extension)
+  (message (g-object webkit-user-message))
+  (cancellable :pointer)  ; GCancellable
+  (callback g-async-ready-callback)
+  (user-data :pointer))
+(export 'webkit-web-extension-send-message-to-context)
+
+(defcfun "webkit_web_extension_send_message_to_context_finish" (g-object webkit-user-message)
+  (extension webkit-web-extension)
+  (result g-async-result)
+  (error (:pointer (:struct glib:g-error))))
+(export 'webkit-web-extension-send-message-to-context-finish)


### PR DESCRIPTION
This adds the bindings for the `WebKitWebExtension` and things it depends on.

While WebKit-native extensions are somewhat restricted, they still may bring potential benefits to the users of this library.

### What's There

Bindings for:
- `WebKitUserMessage`
- `WebKitWebExtension` 

### Caveats
- `GUnixFDList` is not yet implemented in `cl-cffi-gtk`, so it's used as pointer. This is vague and unsafe, so having a proper binding for `GUnixFDList` would be better. It works, though.

### How Has This Been Tested

Unfortunately, I haven't found an easy-to-use example extension for WebKit (especially the one with clear compilation instructions!), so this patchset wasn't tested with a real extension. It compiles, at least.

I'll be glad to know what you think of it!

EDIT: Grammar.