### PR TITLE
User content injections

### DIFF
--- a/webkit2/cl-webkit2.asd
+++ b/webkit2/cl-webkit2.asd
@@ -54,6 +54,7 @@
                (:file "webkit2.navigation-policy-decision")
                (:file "webkit2.response-policy-decision")
                (:file "webkit2.navigation-action")
+               (:file "webkit2.user-content")
                (:file "webkit2.user-content-manager")
                (:file "webkit2.network-proxy-settings")
                (:file "webkit2.web-context")

--- a/webkit2/webkit2.user-content-manager.lisp
+++ b/webkit2/webkit2.user-content-manager.lisp
@@ -11,3 +11,66 @@
 (in-package #:webkit2)
 
 (define-webkit-class "WebKitUserContentManager" () ())
+
+(defcfun "webkit_user_content_manager_new" (g-object webkit-user-content-manager))
+(export 'webkit-user-content-manager-new)
+
+(defcfun "webkit_user_content_manager_add_style_sheet" :void
+  (manager (g-object webkit-user-content-manager))
+  (stylesheet webkit-user-style-sheet))
+(export 'webkit-user-content-manager-add-style-sheet)
+
+(defcfun "webkit_user_content_manager_remove_all_style_sheets" :void
+  (manager (g-object webkit-user-content-manager)))
+(export 'webkit-user-content-manager-remove-all-style-sheets)
+
+(defcfun "webkit_user_content_manager_add_script" :void
+  (manager (g-object webkit-user-content-manager))
+  (script webkit-user-script))
+(export 'webkit-user-content-manager-add-script)
+
+(defcfun "webkit_user_content_manager_remove_all_scripts" :void
+  (manager (g-object webkit-user-content-manager)))
+(export 'webkit-user-content-manager-remove-all-scripts)
+
+(defcfun "webkit_user_content_manager_register_script_message_handle" :boolean
+  (manager (g-object webkit-user-content-manager))
+  (name :string))
+(export 'webkit-user-content-manager-register-script-message-handle)
+
+(defcfun "webkit_user_content_manager_unregister_script_message_handler" :void
+  (manager (g-object webkit-user-content-manager))
+  (name :string))
+(export 'webkit-user-content-manager-unregister-script-message-handler)
+
+(defcfun "webkit_user_content_manager_register_script_message_handler_in_world" :boolean
+  (manager (g-object webkit-user-content-manager))
+  (name :string)
+  (world-name :string))
+(export 'webkit-user-content-manager-register-script-message-handler-in-world)
+
+(defcfun "webkit_user_content_manager_unregister_script_message_handler_in_world" :void
+  (manager (g-object webkit-user-content-manager))
+  (name :string)
+  (world-name :string))
+(export 'webkit-user-content-manager-unregister-script-message-handler-in-world)
+
+(defcfun "webkit_user_content_manager_add_filter" :void
+  (manager (g-object webkit-user-content-manager))
+  (filter webkit-user-content-filter))
+(export 'webkit-user-content-manager-add-filter)
+
+(defcfun "webkit_user_content_manager_remove_filter" :void
+  (manager (g-object webkit-user-content-manager))
+  (filter webkit-user-content-filter))
+(export 'webkit-user-content-manager-remove-filter)
+
+(defcfun "webkit_user_content_manager_remove_filter_by_id" :void
+  (manager (g-object webkit-user-content-manager))
+  (filter-id :string))
+(export 'webkit-user-content-manager-remove-filter-by-id)
+
+(defcfun "webkit_user_content_manager_remove_all_filters" :void
+  (manager (g-object webkit-user-content-manager)))
+(export 'webkit-user-content-manager-remove-all-filters)
+

--- a/webkit2/webkit2.user-content.lisp
+++ b/webkit2/webkit2.user-content.lisp
@@ -1,0 +1,91 @@
+;;; webkit2.user-content.lisp --- bindings for WebKit-usable user content
+
+;; This file is part of cl-webkit.
+;;
+;; cl-webkit is free software; you can redistribute it and/or modify
+;; it under the terms of the MIT license.
+;; See `COPYING' in the source distribution for details.
+
+;;; Code:
+
+(in-package #:webkit2)
+
+(defctype webkit-user-style-sheet :pointer) ;; GBoxed struct WebKitUserStyleSheet
+
+(defctype webkit-user-script :pointer) ;; GBoxed struct WebKitUserScript
+
+(defctype webkit-user-content-filter :pointer) ;; GBoxed struct WebKitUserContentFilter
+
+(define-g-enum "WebKitUserContentInjectedFrames" webkit-user-content-injected-frames ()
+  :webkit-user-content-inject-all-frames
+  :webkit-user-content-inject-top-frame)
+
+(define-g-enum "WebKitUserStyleLevel" webkit-user-style-level ()
+  :webkit-user-style-level-user
+  :webkit-user-style-level-author)
+
+(define-g-enum "WebKitUserScriptInjectionTime" webkit-user-script-injection-time ()
+  :webkit-user-script-inject-at-document-start
+  :webkit-user-script-inject-at-document-end)
+
+(defcfun "webkit_user_style_sheet_ref" webkit-user-style-sheet
+  (user-style-sheet webkit-user-style-sheet))
+(export 'webkit-user-style-sheet-ref)
+
+(defcfun "webkit_user_style_sheet_unref" :void
+  (user-style-sheet webkit-user-style-sheet))
+(export 'webkit-user-style-sheet-unref)
+
+(defcfun "webkit_user_style_sheet_new" webkit-user-style-sheet
+  (source :string)
+  (injected-frames webkit-user-content-injected-frames)
+  (level webkit-user-style-level)
+  (allow-list :pointer) ;; const gchar * const *
+  (block-list :pointer)) ;; const gchar * const *
+(export 'webkit-user-style-sheet-new)
+
+(defcfun "webkit_user_style_sheet_new_for_world" webkit-user-style-sheet
+  (source :string)
+  (injected-frames webkit-user-content-injected-frames)
+  (level webkit-user-style-level)
+  (world-name :string)
+  (allow-list :pointer) ;; const gchar * const *
+  (block-list :pointer)) ;; const gchar * const *
+(export 'webkit-user-style-sheet-new-for-world)
+
+(defcfun "webkit_user_script_ref" webkit-user-script
+  (user-script webkit-user-script))
+(export 'webkit-user-script-ref)
+
+(defcfun "webkit_user_script_unref" :void
+  (user-script webkit-user-script))
+(export 'webkit-user-script-unref)
+
+(defcfun "webkit_user_script_new" webkit-user-script
+  (source :string)
+  (injected-frames webkit-user-content-injected-frames)
+  (injection-time webkit-user-script-injection-time)
+  (allow-list :pointer) ;; const gchar * const *
+  (block-list :pointer)) ;; const gchar * const *
+(export 'webkit-user-script-new)
+
+(defcfun "webkit_user_script_new_for_world" webkit-user-script
+  (source :string)
+  (injected-frames webkit-user-content-injected-frames)
+  (injection-time webkit-user-script-injection-time)
+  (world-name :string)
+  (allow-list :pointer) ;; const gchar * const *
+  (block-list :pointer)) ;; const gchar * const *
+(export 'webkit-user-script-new-for-world)
+
+(defcfun "webkit_user_content_filter_ref" webkit-user-content-filter
+  (user-content-filter webkit-user-content-filter))
+(export 'webkit-user-content-filter-ref)
+
+(defcfun "webkit_user_content_filter_unref" :void
+  (user-content-filter webkit-user-content-filter))
+(export 'webkit-user-content-filter-unref)
+
+(defcfun "webkit_user_content_filter_get_identifier" :pointer ;; const char *
+  (user-content-filter webkit-user-content-filter))
+(export 'webkit-user-content-filter-get-identifier)

--- a/webkit2/webkit2.web-view.lisp
+++ b/webkit2/webkit2.web-view.lisp
@@ -83,6 +83,10 @@
 
 (defctype js-value-ref :pointer)
 
+(defcfun "webkit_web_view_get_user_content_manager" (g-object webkit-user-content-manager)
+  (web-view (g-object webkit-web-view)))
+(export 'webkit-web-view-get-user-content-manager)
+
 (defcfun "webkit_web_view_get_website_data_manager" (g-object webkit-website-data-manager)
   (web-view (g-object webkit-web-view)))
 (export 'webkit-web-view-get-website-data-manager)


### PR DESCRIPTION
This adds the ability to inject webpages with user scripts, style sheets and filters.

### Motivation

- Dark mode is a necessity :) 
- Injecting JS/CSS into the page source can make browsing easier to customize.

### What's New
- Bindings for all the functions of [`WebKitUserContentManager`](https://webkitgtk.org/reference/webkit2gtk/stable/WebKitUserContentManager.html).
- Bindings for [user content types](https://webkitgtk.org/reference/webkit2gtk/stable/webkit2gtk-4.0-WebKitUserContent.html) (`WebKitUserContentFilter`, `WebKitUserScript`, `WebKitUserStyleSheet`) and functions on them.

### How Has This Been Tested

- I've added a `styled-browser-main` testing function that makes all the text in the `body` red.
- I've also tried to repaint background to black, but it lasted only for a second. I don't yet understand the reason, but it's not a binding problem, I believe. Dark mode should be made using JS, not plain CSS, probably.

Let me know what you think of it!