### PR TITLE
Treat GErrors consistently.

### DIFF
--- a/webkit2/webkit2.cookie-manager.lisp
+++ b/webkit2/webkit2.cookie-manager.lisp
@@ -44,7 +44,7 @@
 (defcfun ("webkit_cookie_manager_get_accept_policy_finish" %webkit-cookie-manager-get-accept-policy-finish) webkit-cookie-accept-policy
   (webkit-cookie-manager (g-object webkit-cookie-manager))
   (result :pointer)
-  (gerror :pointer))
+  (g-error :pointer))
 
 (defun webkit-cookie-manager-get-accept-policy-finish (cookie-manager result)
   (glib:with-g-error (err)
@@ -61,7 +61,7 @@
 (defcfun ("webkit_cookie_manager_get_domains_with_cookies_finish" %webkit-cookie-manager-get-domains-with-cookies-finish) :string
   (webkit-cookie-manager (g-object webkit-cookie-manager))
   (result :pointer)
-  (gerror :pointer))
+  (g-error :pointer))
 
 (defun webkit-cookie-manager-get-domains-with-cookies-finish (cookie-manager result)
   (glib:with-g-error (err)

--- a/webkit2/webkit2.web-context.lisp
+++ b/webkit2/webkit2.web-context.lisp
@@ -103,7 +103,7 @@
 (defcfun ("webkit_web_context_get_plugins_finish" %webkit-web-context-get-plugins-finish) (glib:g-list webkit-plugin)
   (webkit-web-context (g-object webkit-web-context))
   (result g-async-result)
-  (gerror :pointer))
+  (g-error :pointer))
 
 (defun webkit-web-context-get-plugins-finish (web-context result)
   (glib:with-g-error (err)

--- a/webkit2/webkit2.web-extension.lisp
+++ b/webkit2/webkit2.web-extension.lisp
@@ -25,8 +25,12 @@
   (user-data :pointer))
 (export 'webkit-web-extension-send-message-to-context)
 
-(defcfun "webkit_web_extension_send_message_to_context_finish" (g-object webkit-user-message)
+(defcfun ("webkit_web_extension_send_message_to_context_finish" %webkit-web-extension-send-message-to-context-finish) (g-object webkit-user-message)
   (extension webkit-web-extension)
   (result g-async-result)
-  (error (:pointer (:struct glib:g-error))))
+  (g-error :pointer))
+
+(defun webkit-web-extension-send-message-to-context-finish (extension result)
+  (glib:with-g-error (err)
+    (%webkit-web-extension-send-message-to-context-finish extension result err)))
 (export 'webkit-web-extension-send-message-to-context-finish)

--- a/webkit2/webkit2.web-view.lisp
+++ b/webkit2/webkit2.web-view.lisp
@@ -235,7 +235,7 @@
 (defcfun ("webkit_web_view_run_javascript_finish" %webkit-web-view-run-javascript-finish) webkit-javascript-result
   (web-view (g-object webkit-web-view))
   (result g-async-result)
-  (gerror :pointer))
+  (g-error :pointer))
 
 (defun webkit-web-view-run-javascript-finish (web-view result)
   (glib:with-g-error (err)
@@ -253,7 +253,7 @@
 (defcfun ("webkit_web_view_run_javascript_from_gresource_finish" %webkit-web-view-run-javascript-from-gresource-finish) webkit-javascript-result
   (web-view (g-object webkit-web-view))
   (result g-async-result)
-  (gerror :pointer))
+  (g-error :pointer))
 
 (defun webkit-web-view-run-javascript-from-gresource-finish (web-view result)
   (glib:with-g-error (err)
@@ -311,7 +311,7 @@
 (defcfun ("webkit_web_view_save_finish" %webkit-web-view-save-finish) :pointer ; XXX: GInputStream
   (web-view (g-object webkit-web-view))
   (result g-async-result)
-  (gerror :pointer))
+  (g-error :pointer))
 
 (defun webkit-web-view-save-finish (web-view result)
   (glib:with-g-error (err)
@@ -330,7 +330,7 @@
 (defcfun ("webkit_web_view_save_to_file_finish" %webkit-web-view-save-to-file-finish) :boolean
   (web-view (g-object webkit-web-view))
   (result g-async-result)
-  (gerror :pointer))
+  (g-error :pointer))
 
 (defun webkit-web-view-save-to-file-finish (web-view result)
   (glib:with-g-error (err)
@@ -349,7 +349,7 @@
 (defcfun ("webkit_web_view_get_snapshot_finish" %webkit-web-view-get-snapshot-finish) :pointer ; XXX: cairo_surface_t
   (web-view (g-object webkit-web-view))
   (result g-async-result)
-  (gerror :pointer))
+  (g-error :pointer))
 
 (defun webkit-web-view-get-snapshot-finish (web-view result)
   (glib:with-g-error (err)
@@ -389,7 +389,7 @@
 (defcfun ("webkit_web_view_can_execute_editing_command_finish" %webkit-web-view-can-execute-editing-command-finish) :boolean
   (web-view (g-object webkit-web-view))
   (result g-async-result)
-  (gerror :pointer))
+  (g-error :pointer))
 
 (defun webkit-web-view-can-execute-editing-command-finish (web-view result)
   (glib:with-g-error (err)

--- a/webkit2/webkit2.website-data-manager.lisp
+++ b/webkit2/webkit2.website-data-manager.lisp
@@ -92,10 +92,14 @@
   (user-data :pointer))
 (export 'webkit-website-data-manager-fetch)
 
-(defcfun "webkit_website_data_manager_fetch_finish" (glib:g-list webkit-website-data)
+(defcfun ("webkit_website_data_manager_fetch_finish" %webkit-website-data-manager-fetch-finish) (glib:g-list webkit-website-data)
   (manager (g-object webkit-website-data-manager))
   (result g-async-result)
-  (error (:pointer (:struct glib:g-error))))
+  (g-error :pointer))
+
+(defun webkit-website-data-manager-fetch-finish (manager result)
+  (glib:with-g-error (err)
+    (%webkit-website-data-manager-fetch-finish manager result err)))
 (export 'webkit-website-data-manager-fetch-finish)
 
 (defcfun "webkit_website_data_manager_remove" :void
@@ -107,10 +111,14 @@
   (user-data :pointer))
 (export 'webkit-website-data-manager-remove)
 
-(defcfun "webkit_website_data_manager_remove_finish" :boolean
+(defcfun ("webkit_website_data_manager_remove_finish" %webkit-website-data-manager-remove-finish) :boolean
   (manager (g-object webkit-website-data-manager))
   (result g-async-result)
-  (error (:pointer (:struct glib:g-error))))
+  (g-error :pointer))
+
+(defun webkit-website-data-manager-remove-finish (manager result)
+  (glib:with-g-error (err)
+    (%webkit-website-data-manager-remove-finish manager result err)))
 (export 'webkit-website-data-manager-remove-finish)
 
 (defcfun "webkit_website_data_manager_clear" :void
@@ -122,10 +130,14 @@
   (user-data :pointer))
 (export 'webkit-website-data-manager-clear)
 
-(defcfun "webkit_website_data_manager_clear_finish" :boolean
+(defcfun ("webkit_website_data_manager_clear_finish" %webkit-website-data-manager-clear-finish) :boolean
   (manager (g-object webkit-website-data-manager))
   (result g-async-result)
-  (error (:pointer (:struct glib:g-error))))
+  (g-error :pointer))
+
+(defun webkit-website-data-manager-clear-finish (manager result)
+  (glib:with-g-error (err)
+    (%webkit-website-data-manager-clear-finish manager result err)))
 (export 'webkit-website-data-manager-clear-finish)
 
 #+webkit2-tracking
@@ -192,9 +204,14 @@
 (export 'webkit-website-data-manager-get-itp-summary)
 
 #+webkit2-tracking
-(defcfun "webkit_website_data_manager_get_itp_summary_finish" (glib:g-list webkit-itp-first-party)
+(defcfun ("webkit_website_data_manager_get_itp_summary_finish" %webkit-website-data-manager-get-itp-summary-finish) (glib:g-list webkit-itp-first-party)
   (manager (g-object webkit-website-data-manager))
   (result g-async-result)
-  (error (:pointer (:struct glib:g-error))))
+  (g-error :pointer))
+
+#+webkit2-tracking
+(defun webkit-website-data-manager-get-itp-summary-finish (manager result)
+  (glib:with-g-error (err)
+    (%webkit-website-data-manager-get-itp-summary-finish manager result err)))
 #+webkit2-tracking
 (export 'webkit-website-data-manager-get-itp-summary-finish)


### PR DESCRIPTION
This makes our treatment of GErrors more consistent. In particular:
- Refer to all the GError arguments to WebKit functions as `g-error` to mimic `glib:with-g-error` and escape collisions with the editor coloring for `error`.
- Make all the error args have `:pointer` type. This is also consistent with `glib:with-g-error` that expects `:pointer`s.
- Wrap all the functions with `g-error` args into `glib:with-g-error`.

### How Has This Been Tested

It compiles without errors. All the functions were tested before, what I did was only wrapping these into `glib:with-g-error`. No additional testing is needed then.

How does it look to you?

Closes #44.

EDIT: Reference the issue to close after merging.