### PR TITLE
Add bindings for WebKitURISchemeRequest.

### DIFF
--- a/webkit2/cl-webkit2.asd
+++ b/webkit2/cl-webkit2.asd
@@ -63,6 +63,7 @@
                (:file "webkit2.website-data-manager")
                (:file "webkit2.web-inspector")
                (:file "webkit2.web-view")
+               (:file "webkit2.uri-scheme-request")
                (:file "webkit2.window-properties")
                (:file "webkit2.uri-utilities")
                (:file "webkit2.user-message")

--- a/webkit2/webkit2.uri-scheme-request.lisp
+++ b/webkit2/webkit2.uri-scheme-request.lisp
@@ -1,0 +1,70 @@
+;;; webkit2.uri-scheme-request.lisp --- bindings for WebKitURISchemeRequest
+
+;; This file is part of cl-webkit.
+;;
+;; cl-webkit is free software; you can redistribute it and/or modify
+;; it under the terms of the MIT license.
+;; See `COPYING' in the source distribution for details.
+
+;;; Code:
+
+(in-package #:webkit2)
+
+(defctype webkit-uri-scheme-request :pointer)
+
+(defcfun "webkit_uri_scheme_request_get_scheme" :string
+  (request webkit-uri-scheme-request))
+(export 'webkit-uri-scheme-request-get-scheme)
+
+(defcfun "webkit_uri_scheme_request_get_uri" :string
+  (request webkit-uri-scheme-request))
+(export 'webkit-uri-scheme-request-get-uri)
+
+(defcfun "webkit_uri_scheme_request_get_path" :string
+  (request webkit-uri-scheme-request))
+(export 'webkit-uri-scheme-request-get-path)
+
+(defcfun "webkit_uri_scheme_request_get_web-view" (g-object webkit-web-view)
+  (request webkit-uri-scheme-request))
+(export 'webkit-uri-scheme-request-get-web-view)
+
+(defcfun "webkit_uri_scheme_request_finish" :void
+  (request webkit-uri-scheme-request)
+  (stream :pointer)  ; XXX: GInputStream
+  (stream-length :int)
+  (contents :string))
+(export 'webkit-uri-scheme-request-finish)
+
+(defcfun ("webkit_uri_scheme_request_finish_error" %webkit-uri-scheme-request-finish-error) :void
+  (request webkit-uri-scheme-request)
+  (g-error :pointer))
+
+(defun webkit-uri-scheme-request-finish-error (request)
+  (glib:with-g-error (err)
+    (%webkit-uri-scheme-request-finish-error request err)))
+(export 'webkit-uri-scheme-request-finish-error)
+
+(cffi:defcallback uri-scheme-processed :void ((request :pointer) (user-data :pointer))
+  (let ((callback (find (cffi:pointer-address user-data) callbacks :key (function callback-id))))
+    (handler-case
+        (progn
+          (setf callbacks (delete callback callbacks))
+          (when (callback-function callback)
+            (funcall (callback-function callback) request)))
+      (error (c)
+        (when callback
+          (when  (callback-error-function callback)
+            (funcall (callback-error-function callback) c))
+          (setf callbacks (delete callback callbacks)))))))
+
+(defun webkit-web-context-register-uri-scheme-callback (context scheme &optional call-back error-call-back)
+  (incf callback-counter)
+  (push (make-callback :id callback-counter :data context
+                       :function call-back
+                       :error-function error-call-back)
+        callbacks)
+  (webkit-web-context-register-uri-scheme
+   context scheme
+   (cffi:callback uri-scheme-processed)
+   (cffi:make-pointer callback-counter)
+   (cffi:null-pointer)))

--- a/webkit2/webkit2.web-view.lisp
+++ b/webkit2/webkit2.web-view.lisp
@@ -189,7 +189,7 @@
 (defvar callbacks ())
 (defstruct callback
   (id callback-counter :type number)
-  web-view
+  data
   (function nil :type (or function null))
   (error-function nil :type (or function null)))
 
@@ -198,7 +198,7 @@
   (declare (ignore source-object))
   (let ((callback (find (cffi:pointer-address user-data) callbacks :key (function callback-id))))
     (handler-case
-        (let* ((js-result (webkit-web-view-run-javascript-finish (callback-web-view callback) result))
+        (let* ((js-result (webkit-web-view-run-javascript-finish (callback-data callback) result))
                (context (webkit-javascript-result-get-global-context js-result))
                (value (webkit-javascript-result-get-value js-result))
                (js-str-value (jscore:js-value-to-string-copy context value (cffi:null-pointer)))
@@ -221,7 +221,7 @@
 (defun webkit-web-view-evaluate-javascript (web-view javascript &optional call-back error-call-back)
   "Evaluate javascript in web-view calling call-back upon completion."
   (incf callback-counter)
-  (push (make-callback :id callback-counter :web-view web-view
+  (push (make-callback :id callback-counter :data web-view
                        :function call-back
                        :error-function error-call-back)
         callbacks)


### PR DESCRIPTION
This adds bindings for `WebKitURISchemeRequest`. 

### Motivation

Custom URI schemes are a reality of browser-making ([Firefox and `about:`](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/The_about_protocol), Chrome and Firefox's with `chrome:`). Because of that, bindings for an object that manages custom URIs are a must-have in our bindings.

### What's new

- Bindings for all the functions on [WebKitURISchemeRequest](https://webkitgtk.org/reference/webkit2gtk/stable/WebKitURISchemeRequest.html).
- Small generalization of callbacks in `webkit2.web-view.lisp` -- these are useful for URI scheme callbacks too.

### Caveats

This change is not bringing anything without support for `GInputStream`, because most of useful functions rely on `GInputStream` for HTML output. This struct is part of GIO, so we shouldn't write our home-made wrappers around it in this repo. Maybe ask `cl-cffi-gtk` for implementations or at least some pointers for implementation?

### How Has This Been Tested

It compiles. Further testing is hindered by inability to use `GInputStream`.

How does it look to you?

EDIT: Minor grammar.