### PR TITLE
Add favicons support.

### DIFF
--- a/webkit2/webkit2.web-view.lisp
+++ b/webkit2/webkit2.web-view.lisp
@@ -33,6 +33,7 @@
   (:superclass gtk-widget
    :interfaces ("AtkImplementorIface" "GtkBuildable"))
   (("estimated-load-progress" "gdouble")
+   ("favicon" "gpointer")
    ("is-ephemeral" "gboolean")
    ("is-loading" "gboolean")
    #+webkit2-mute
@@ -93,6 +94,10 @@
 (defcfun "webkit_web_view_get_website_data_manager" (g-object webkit-website-data-manager)
   (web-view (g-object webkit-web-view)))
 (export 'webkit-web-view-get-website-data-manager)
+
+(defcfun "webkit_web_view_get_favicon" :pointer
+  (web-view (g-object webkit-web-view)))
+(export 'webkit-web-view-get-favicon)
 
 (defcfun "webkit_web_view_load_uri" :void
   (web-view (g-object webkit-web-view))


### PR DESCRIPTION
This is a small change that adds the WebKit-native favicons handling. 

It can help with https://github.com/atlas-engineer/nyxt/issues/1092, but first we need to understand how to handle `cairo_surface_t` xD