### PR TITLE
Add webkit-web-view-evaluate-javascript-from-gresource.

### DIFF
--- a/webkit2/webkit2.web-view.lisp
+++ b/webkit2/webkit2.web-view.lisp
@@ -224,7 +224,7 @@
           (setf callbacks (delete callback callbacks)))))))
 
 (defun webkit-web-view-evaluate-javascript (web-view javascript &optional call-back error-call-back)
-  "Evaluate javascript in web-view calling call-back upon completion."
+  "Evaluate JAVASCRIPT in WEB-VIEW calling CALL-BACK upon completion."
   (incf callback-counter)
   (push (make-callback :id callback-counter :web-view web-view
                        :function call-back
@@ -264,6 +264,20 @@
   (glib:with-g-error (err)
     (%webkit-web-view-run-javascript-from-gresource-finish web-view result err)))
 (export 'webkit-web-view-run-javascript-from-gresource-finish)
+
+(defun webkit-web-view-evaluate-javascript-from-gresource (web-view resource &optional call-back error-call-back)
+  "Evaluate JavaScript from RESOURCE in WEB-VIEW calling CALL-BACK upon completion and ERROR-CALL-BACK on error."
+  (incf callback-counter)
+  (push (make-callback :id callback-counter :web-view web-view
+                       :function call-back
+                       :error-function error-call-back)
+        callbacks)
+  (webkit-web-view-run-javascript-from-gresource
+   web-view resource
+   (cffi:null-pointer)
+   (cffi:callback javascript-evaluation-complete)
+   (cffi:make-pointer callback-counter)))
+(export 'webkit-web-view-evaluate-javascript-from-gresource)
 
 (defcfun "webkit_web_view_download_uri" (g-object webkit-download)
   (web-view (g-object webkit-web-view))


### PR DESCRIPTION
This adds `webkit-web-view-evaluate-javascript-from-gresource` -- a convenience function akin to `webkit-web-view-evaluate-javascript`, yet with loading from `gresource`.

# Applications
- I've started implementing `readability-mode` for Nyxt similar to Reader View of Epiphany. They use `gresource` to load third party library (namely Mozilla's Readability.js). That's for a reason -- plain JavaScript evaluation errors out because of complex object interrelation in the library. So, to implement `readability-mode`, I need to have JavaScript evaluation from `gresource`
- This can also be used to implement `ffi-buffer-load-javascript-from-file` -- a general-purpose library-loading function that can be useful (e.g. https://github.com/atlas-engineer/nyxt/issues/213), especially for third-party extensions. Draft implementation is:
``` lisp
(defmethod ffi-buffer-load-javascript-from-file ((buffer gtk-buffer) pathname)
  (let ((xml-pathname (merge-pathnames (pathname (str:concat (pathname-name pathname) ".gresource.xml"))
                                       (uiop:pathname-directory-pathname pathname)))
        (xml `(:gresources
               (:gresource :prefix ,(uiop:pathname-directory-pathname pathname)
                           (:file :compressed "true" (str:concat ,(pathname-name pathname)
                                                                 "."
                                                                 ,(pathname-type pathname)))))))
    (with-open-file (file xml-pathname
                          :direction :output
                          :if-does-not-exist :create
                          :if-exists :supersede)
      (princ (eval `(markup:xml ,xml)) file)
      (webkit:webkit-web-view-evaluate-javascript-from-gresource
       (gtk-object buffer)
       (uiop:native-namestring pathname)))))
```
And most of the code is XML generation for `gresource` xD


# Caveats
- `webkit-web-view-run-javascript-finish` is used to get results of evaluation from `gresource`. Epiphany people do that, so it shouldn't be dangerous. However, using `webkit-web-view-run-javascript-from-gresource-finish` can be cleaner and more consistent. Is it worth duplicating `javascript-evaluation-complete` callback with just one line altered?

# How Has This Been Tested
- `cl-webkit` compiles with no warnings on this patch. 
- This patch relies on battle-tested building blocks like `javascript-evaluation-complete`, so it shouldn't break terribly.

EDIT: Battle-tested.