### PR TITLE
Add bindings for WebKitURISchemeRequest.

### DIFF
--- a/demo/simple-browser.lisp
+++ b/demo/simple-browser.lisp
@@ -115,8 +115,9 @@ Loads and renders a single web page."
       (webkit:webkit-web-context-register-uri-scheme-callback
        context "hello"
        #'(lambda (request)
-           (format nil "<html><body><p>Hello, ~:(~a~)!</p></body></html>"
-                   (webkit:webkit-uri-scheme-request-get-path request))))
+           (values (format nil "Hello, ~:(~a~)!"
+                           (webkit:webkit-uri-scheme-request-get-path request))
+                   "text/plain")))
       (gtk:gtk-container-add win view)
       (webkit2:webkit-web-view-load-uri view "hello:stranger")
       (gtk:gtk-widget-show-all win))))

--- a/demo/simple-browser.lisp
+++ b/demo/simple-browser.lisp
@@ -101,10 +101,31 @@ Loads and renders a single web page."
       (webkit2:webkit-web-view-load-uri view "http://www.example.com")
       (gtk:gtk-widget-show-all win))))
 
-(defun test-browser-main (&key private extended styled)
+(defun custom-scheme-browser-main ()
+  "A version of `simple-browser-main' that adds a hello: scheme that greets the user."
+  (gtk:within-main-loop
+    (let* ((win (make-instance 'gtk:gtk-window))
+           (context (make-instance 'webkit:webkit-web-context))
+           (view (make-instance 'webkit2:webkit-web-view
+                                :web-context context)))
+      (gobject:g-signal-connect win "destroy"
+                                #'(lambda (widget)
+                                    (declare (ignore widget))
+                                    (gtk:leave-gtk-main)))
+      (webkit:webkit-web-context-register-uri-scheme-callback
+       context "hello"
+       #'(lambda (request)
+           (values "text/html" (format nil "<html><body><p>Hello, ~:(~a~)!</p></body></html>"
+                                       (webkit:webkit-uri-scheme-request-get-path request)))))
+      (gtk:gtk-container-add win view)
+      (webkit2:webkit-web-view-load-uri view "hello:stranger")
+      (gtk:gtk-widget-show-all win))))
+
+(defun test-browser-main (&key private extended styled custom-scheme)
   (cond
     (private (private-browser-main))
     (extended (extended-browser-main))
     (styled (styled-browser-main))
+    (custom-scheme (custom-scheme-browser-main))
     (t (simple-browser-main)))
   (gtk:join-gtk-main))

--- a/demo/simple-browser.lisp
+++ b/demo/simple-browser.lisp
@@ -115,8 +115,8 @@ Loads and renders a single web page."
       (webkit:webkit-web-context-register-uri-scheme-callback
        context "hello"
        #'(lambda (request)
-           (values "text/html" (format nil "<html><body><p>Hello, ~:(~a~)!</p></body></html>"
-                                       (webkit:webkit-uri-scheme-request-get-path request)))))
+           (format nil "<html><body><p>Hello, ~:(~a~)!</p></body></html>"
+                   (webkit:webkit-uri-scheme-request-get-path request))))
       (gtk:gtk-container-add win view)
       (webkit2:webkit-web-view-load-uri view "hello:stranger")
       (gtk:gtk-widget-show-all win))))

--- a/demo/simple-browser.lisp
+++ b/demo/simple-browser.lisp
@@ -115,9 +115,8 @@ Loads and renders a single web page."
       (webkit:webkit-web-context-register-uri-scheme-callback
        context "hello"
        #'(lambda (request)
-           (values (format nil "Hello, ~:(~a~)!"
-                           (webkit:webkit-uri-scheme-request-get-path request))
-                   "text/plain")))
+           (format nil "<html><body><p>Hello, ~:(~a~)!</p></body></html>"
+                   (webkit:webkit-uri-scheme-request-get-path request))))
       (gtk:gtk-container-add win view)
       (webkit2:webkit-web-view-load-uri view "hello:stranger")
       (gtk:gtk-widget-show-all win))))

--- a/webkit2/cl-webkit2.asd
+++ b/webkit2/cl-webkit2.asd
@@ -63,6 +63,7 @@
                (:file "webkit2.website-data-manager")
                (:file "webkit2.web-inspector")
                (:file "webkit2.web-view")
+               (:file "webkit2.g-input-stream")
                (:file "webkit2.uri-scheme-request")
                (:file "webkit2.window-properties")
                (:file "webkit2.uri-utilities")

--- a/webkit2/cl-webkit2.asd
+++ b/webkit2/cl-webkit2.asd
@@ -63,6 +63,7 @@
                (:file "webkit2.website-data-manager")
                (:file "webkit2.web-inspector")
                (:file "webkit2.web-view")
+               (:file "webkit2.uri-scheme-request")
                (:file "webkit2.window-properties")
                (:file "webkit2.uri-utilities")
                (:file "webkit2.user-message")

--- a/webkit2/webkit2.g-input-stream.lisp
+++ b/webkit2/webkit2.g-input-stream.lisp
@@ -43,3 +43,14 @@
   (declare (ignore data)))
 (cffi:defcallback g-notify-destroy-free :void ((data :pointer))
   (cffi:foreign-funcall "free" :pointer data))
+
+(cffi:defcfun ("g_input_stream_read" %g-input-stream-read) :uint
+  (stream (g:g-object webkit::g-input-stream))
+  (buffer :pointer)
+  (count :uint)
+  (cancellable :pointer)
+  (g-error :pointer))
+
+(defun g-input-stream-read (stream buffer count)
+  (glib:with-g-error (err)
+    (%g-input-stream-read stream buffer count (cffi:null-pointer) err)))

--- a/webkit2/webkit2.g-input-stream.lisp
+++ b/webkit2/webkit2.g-input-stream.lisp
@@ -1,0 +1,37 @@
+;;; webkit2.g-input-stream.lisp --- bindings for GInputStream & derivatives
+
+;; This file is part of cl-webkit.
+;;
+;; cl-webkit is free software; you can redistribute it and/or modify
+;; it under the terms of the MIT license.
+;; See `COPYING' in the source distribution for details.
+
+;;; Commentary
+
+;; This should ideally be part of cl-cffi-gtk, but it's not complete
+;; enough to merge to upstream, while we urgently need it for
+;; WebKitURISchemeRequest bindings.
+
+;;; Code:
+
+(in-package #:webkit2)
+
+(define-g-object-class "GInputStream" g-input-stream
+    (:export nil
+     :type-initializer "g_input_stream_get_type")
+    ())
+(define-g-object-class "GMemoryInputStream" g-memory-input-stream
+    (:superclass g-input-stream
+     :export nil
+     :type-initializer "g_memory_input_stream_get_type")
+    ())
+
+(defcfun "g_memory_input_stream_new_from_data" (g-object g-memory-input-stream)
+  (data :pointer)
+  (length :long)
+  (destroy :pointer))
+
+(cffi:defcallback g-notify-destroy-null :void ((data :pointer))
+  (declare (ignore data)))
+(cffi:defcallback g-notify-destroy-free :void ((data :pointer))
+  (cffi:foreign-funcall "free" :pointer data))

--- a/webkit2/webkit2.g-input-stream.lisp
+++ b/webkit2/webkit2.g-input-stream.lisp
@@ -16,6 +16,13 @@
 
 (in-package #:webkit2)
 
+(define-g-interface "GSeekable" g-seekable
+    (:export nil
+     :type-initializer "g_seekable_get_type"))
+(define-g-interface "GPollableInputStream" g-pollable-input-stream
+    (:export nil
+     :type-initializer "g_pollable_input_stream_get_type"))
+
 (define-g-object-class "GInputStream" g-input-stream
     (:export nil
      :type-initializer "g_input_stream_get_type")
@@ -23,6 +30,7 @@
 (define-g-object-class "GMemoryInputStream" g-memory-input-stream
     (:superclass g-input-stream
      :export nil
+     :interfaces ("GPollableInputStream" "GSeekable")
      :type-initializer "g_memory_input_stream_get_type")
     ())
 

--- a/webkit2/webkit2.uri-scheme-request.lisp
+++ b/webkit2/webkit2.uri-scheme-request.lisp
@@ -92,6 +92,14 @@
               (funcall (callback-error-function callback) c))))))))
 
 (defun webkit-web-context-register-uri-scheme-callback (context scheme &optional call-back error-call-back)
+  "Register the custom scheme.
+Hide all the unpretty details (callbacks, WebKit functions, C objects
+allocation) from the Lisp-side.
+
+CONTEXT is the `webkit-web-context' to register scheme for.
+SCHEME is the name of the scheme as a string.
+CALL-BACK is a callback of one argument -- a WebKitURISchemeRequest for this scheme.
+ERROR-CALL-BACK is the one-argument function to call on error if it happens."
   (incf callback-counter)
   (push (make-callback :id callback-counter :web-view context
                        :function call-back

--- a/webkit2/webkit2.uri-scheme-request.lisp
+++ b/webkit2/webkit2.uri-scheme-request.lisp
@@ -58,7 +58,7 @@
       ;; Callback function returns data-string as a first value
       ;; and data type (e.g., "text/html") as an optional second
       ;; value.
-      (destructuring-bind (data &optional (data-type "text-html"))
+      (destructuring-bind (data &optional (data-type "text/html"))
           (multiple-value-list (funcall (callback-function callback) request))
         (handler-case
             (multiple-value-bind (ffi-string ffi-string-length)

--- a/webkit2/webkit2.uri-scheme-request.lisp
+++ b/webkit2/webkit2.uri-scheme-request.lisp
@@ -42,7 +42,7 @@
   (request (g-object webkit-uri-scheme-request))
   (stream (g-object g-memory-input-stream))
   (stream-length :long)
-  (contents :string))
+  (content-type :string))
 (export 'webkit-uri-scheme-request-finish)
 
 (defcfun ("webkit_uri_scheme_request_finish_error" %webkit-uri-scheme-request-finish-error) :void

--- a/webkit2/webkit2.uri-scheme-request.lisp
+++ b/webkit2/webkit2.uri-scheme-request.lisp
@@ -12,15 +12,6 @@
 
 (define-webkit-class "WebKitURISchemeRequest" () ())
 
-(define-g-object-class "GInputStream" g-input-stream
-    (:export nil
-     :type-initializer "g_input_stream_get_type")
-    ())
-(define-g-object-class "GMemoryInputStream" g-memory-input-stream
-    (:superclass g-input-stream
-     :export nil
-     :type-initializer "g_memory_input_stream_get_type")
-    ())
 (defvar +webkit-plugin-error-connection-cancelled+ 4
   "A separate value for the connection cancelled plugin error for use
   in WebKitURISchemeRequest callbacks.")
@@ -59,16 +50,6 @@
             +webkit-plugin-error-connection-cancelled+
             error-string)))
 (export 'webkit-uri-scheme-request-finish-error)
-
-(defcfun "g_memory_input_stream_new_from_data" (g-object g-memory-input-stream)
-  (data :pointer)
-  (length :long)
-  (destroy :pointer))
-
-(cffi:defcallback g-notify-destroy-null :void ((data :pointer))
-  (declare (ignore data)))
-(cffi:defcallback g-notify-destroy-free :void ((data :pointer))
-  (cffi:foreign-funcall "free" :pointer data))
 
 (cffi:defcallback uri-scheme-processed :void ((request (g-object webkit-uri-scheme-request))
                                               (user-data :pointer))

--- a/webkit2/webkit2.uri-scheme-request.lisp
+++ b/webkit2/webkit2.uri-scheme-request.lisp
@@ -67,7 +67,8 @@
 (cffi:defcallback g-notify-destroy-free :void ((data :pointer))
   (cffi:foreign-funcall "free" :pointer data))
 
-(cffi:defcallback uri-scheme-processed :void ((request :pointer) (user-data :pointer))
+(cffi:defcallback uri-scheme-processed :void ((request (g-object webkit-uri-scheme-request))
+                                              (user-data :pointer))
   (let ((callback (find (cffi:pointer-address user-data) callbacks :key (function callback-id))))
     (setf callbacks (delete callback callbacks))
     ;; TODO: Use `unwind-protect' to free the allocated objects?

--- a/webkit2/webkit2.uri-scheme-request.lisp
+++ b/webkit2/webkit2.uri-scheme-request.lisp
@@ -72,7 +72,7 @@
                 (cffi:foreign-string-free ffi-string)))
           (error (c)
             (webkit-uri-scheme-request-finish-error
-             request (format nil "The custom url request for URI ~a failed with ~a: ~a"
+             request (format nil "The custom request for URI ~a failed with ~a: ~a"
                              (webkit-uri-scheme-request-get-uri request) (type-of c) c))
             (when (and callback (callback-error-function callback))
               (funcall (callback-error-function callback) c))))))))

--- a/webkit2/webkit2.uri-scheme-request.lisp
+++ b/webkit2/webkit2.uri-scheme-request.lisp
@@ -59,7 +59,7 @@
 
 (defcfun "g_memory_input_stream_new_from_data" (g-object g-memory-input-stream)
   (data :pointer)
-  (length :unsigned-int)
+  (length :long)
   (destroy :pointer))
 
 (cffi:defcallback uri-scheme-processed :void ((request :pointer) (user-data :pointer))

--- a/webkit2/webkit2.uri-scheme-request.lisp
+++ b/webkit2/webkit2.uri-scheme-request.lisp
@@ -34,7 +34,7 @@
   (request (g-object webkit-uri-scheme-request)))
 (export 'webkit-uri-scheme-request-get-path)
 
-(defcfun "webkit_uri_scheme_request_get_web-view" (g-object webkit-web-view)
+(defcfun "webkit_uri_scheme_request_get_web_view" (g-object webkit-web-view)
   (request (g-object webkit-uri-scheme-request)))
 (export 'webkit-uri-scheme-request-get-web-view)
 

--- a/webkit2/webkit2.uri-scheme-request.lisp
+++ b/webkit2/webkit2.uri-scheme-request.lisp
@@ -83,7 +83,7 @@
               (let* ((stream (g-memory-input-stream-new-from-data
                               ffi-string ffi-string-length (callback g-notify-destroy-null))))
                 (webkit-uri-scheme-request-finish request stream ffi-string-length data-type)
-                (gobject:g-object-unref stream)
+                (gobject:g-object-unref (pointer stream))
                 (cffi:foreign-string-free ffi-string)))
           (error (c)
             (webkit-uri-scheme-request-finish-error

--- a/webkit2/webkit2.uri-scheme-request.lisp
+++ b/webkit2/webkit2.uri-scheme-request.lisp
@@ -12,6 +12,16 @@
 
 (define-webkit-class "WebKitURISchemeRequest" () ())
 
+(define-g-object-class "GInputStream" g-input-stream
+    (:export nil
+     :type-initializer "g_input_stream_get_type")
+    ())
+(define-g-object-class "GMemoryInputStream" g-memory-input-stream
+    (:superclass g-input-stream
+     :export nil
+     :type-initializer "g_memory_input_stream_get_type")
+    ())
+
 (defcfun "webkit_uri_scheme_request_get_scheme" :string
   (request (g-object webkit-uri-scheme-request)))
 (export 'webkit-uri-scheme-request-get-scheme)
@@ -46,6 +56,11 @@
             :webkit-plugin-error-connection-cancelled
             error-string)))
 (export 'webkit-uri-scheme-request-finish-error)
+
+(defcfun "g_memory_input_stream_new_from_data" (g-object g-memory-input-stream)
+  (data :pointer)
+  (length :unsigned-int)
+  (destroy :pointer))
 
 (cffi:defcallback uri-scheme-processed :void ((request :pointer) (user-data :pointer))
   (let ((callback (find (cffi:pointer-address user-data) callbacks :key (function callback-id))))

--- a/webkit2/webkit2.uri-scheme-request.lisp
+++ b/webkit2/webkit2.uri-scheme-request.lisp
@@ -21,6 +21,9 @@
      :export nil
      :type-initializer "g_memory_input_stream_get_type")
     ())
+(defvar +webkit-plugin-error-connection-cancelled+ 4
+  "A separate value for the connection cancelled plugin error for use
+  in WebKitURISchemeRequest callbacks.")
 
 (defcfun "webkit_uri_scheme_request_get_scheme" :string
   (request (g-object webkit-uri-scheme-request)))
@@ -53,7 +56,7 @@
   (%webkit-uri-scheme-request-finish-error
    request (glib::%g-error-new-literal
             +webkit-plugin-error+
-            4
+            +webkit-plugin-error-connection-cancelled+
             error-string)))
 (export 'webkit-uri-scheme-request-finish-error)
 

--- a/webkit2/webkit2.uri-scheme-request.lisp
+++ b/webkit2/webkit2.uri-scheme-request.lisp
@@ -63,10 +63,11 @@
         (handler-case
             (multiple-value-bind (ffi-string ffi-string-length)
                 (cffi:foreign-string-alloc data)
-              (let* ((stream (g-memory-input-stream-new-from-data
-                              ffi-string ffi-string-length (callback g-notify-destroy-null))))
-                (webkit-uri-scheme-request-finish request stream ffi-string-length data-type)
-                (gobject:g-object-unref (pointer stream))
+              (unwind-protect
+                   (let* ((stream (g-memory-input-stream-new-from-data
+                                   ffi-string ffi-string-length (callback g-notify-destroy-null))))
+                     (webkit-uri-scheme-request-finish request stream ffi-string-length data-type)
+                     (gobject:g-object-unref (pointer stream)))
                 (cffi:foreign-string-free ffi-string)))
           (error (c)
             (webkit-uri-scheme-request-finish-error

--- a/webkit2/webkit2.uri-scheme-request.lisp
+++ b/webkit2/webkit2.uri-scheme-request.lisp
@@ -53,7 +53,7 @@
   (%webkit-uri-scheme-request-finish-error
    request (glib::%g-error-new-literal
             +webkit-plugin-error+
-            :webkit-plugin-error-connection-cancelled
+            4
             error-string)))
 (export 'webkit-uri-scheme-request-finish-error)
 

--- a/webkit2/webkit2.uri-scheme-request.lisp
+++ b/webkit2/webkit2.uri-scheme-request.lisp
@@ -40,8 +40,8 @@
 
 (defcfun "webkit_uri_scheme_request_finish" :void
   (request (g-object webkit-uri-scheme-request))
-  (stream :pointer)  ; XXX: GInputStream
-  (stream-length :int)
+  (stream (g-object g-memory-input-stream))
+  (stream-length :long)
   (contents :string))
 (export 'webkit-uri-scheme-request-finish)
 

--- a/webkit2/webkit2.uri-scheme-request.lisp
+++ b/webkit2/webkit2.uri-scheme-request.lisp
@@ -79,7 +79,7 @@
 
 (defun webkit-web-context-register-uri-scheme-callback (context scheme &optional call-back error-call-back)
   "Register the custom scheme.
-Hide all the unpretty details (callbacks, WebKit functions, C objects
+Hide all the implementation details (callbacks, WebKit functions, C objects
 allocation) from the Lisp-side.
 
 CONTEXT is the `webkit-web-context' to register scheme for.

--- a/webkit2/webkit2.uri-scheme-request.lisp
+++ b/webkit2/webkit2.uri-scheme-request.lisp
@@ -84,8 +84,12 @@ allocation) from the Lisp-side.
 
 CONTEXT is the `webkit-web-context' to register scheme for.
 SCHEME is the name of the scheme as a string.
-CALL-BACK is a callback of one argument -- a WebKitURISchemeRequest for this scheme.
-ERROR-CALL-BACK is the one-argument function to call on error if it happens."
+CALL-BACK is a callback of one argument -- a WebKitURISchemeRequest
+for this scheme.  It should return two values: the content of the
+response (as a string) and an optional MIME type (e.g. \"text/html\")
+of that response.
+ERROR-CALL-BACK is the one-argument function to call on error if it
+happens."
   (incf callback-counter)
   (push (make-callback :id callback-counter :web-view context
                        :function call-back

--- a/webkit2/webkit2.uri-scheme-request.lisp
+++ b/webkit2/webkit2.uri-scheme-request.lisp
@@ -65,7 +65,8 @@
                 (cffi:foreign-string-alloc data)
               (unwind-protect
                    (let* ((stream (g-memory-input-stream-new-from-data
-                                   ffi-string ffi-string-length (callback g-notify-destroy-null))))
+                                   ffi-string -1 ; -1 is for auto-detection based on NULL character
+                                   (callback g-notify-destroy-null))))
                      (webkit-uri-scheme-request-finish request stream ffi-string-length data-type)
                      (gobject:g-object-unref (pointer stream)))
                 (cffi:foreign-string-free ffi-string)))

--- a/webkit2/webkit2.uri-scheme-request.lisp
+++ b/webkit2/webkit2.uri-scheme-request.lisp
@@ -70,8 +70,6 @@
 (cffi:defcallback uri-scheme-processed :void ((request (g-object webkit-uri-scheme-request))
                                               (user-data :pointer))
   (let ((callback (find (cffi:pointer-address user-data) callbacks :key (function callback-id))))
-    (setf callbacks (delete callback callbacks))
-    ;; TODO: Use `unwind-protect' to free the allocated objects?
     (when (callback-function callback)
       ;; Callback function returns data-string as a first value
       ;; and data type (e.g., "text/html") as an optional second

--- a/webkit2/webkit2.uri-scheme-request.lisp
+++ b/webkit2/webkit2.uri-scheme-request.lisp
@@ -1,0 +1,95 @@
+;;; webkit2.uri-scheme-request.lisp --- bindings for WebKitURISchemeRequest
+
+;; This file is part of cl-webkit.
+;;
+;; cl-webkit is free software; you can redistribute it and/or modify
+;; it under the terms of the MIT license.
+;; See `COPYING' in the source distribution for details.
+
+;;; Code:
+
+(in-package #:webkit2)
+
+(defctype webkit-uri-scheme-request :pointer)
+
+(defcfun "webkit_uri_scheme_request_get_scheme" :string
+  (request webkit-uri-scheme-request))
+(export 'webkit-uri-scheme-request-get-scheme)
+
+(defcfun "webkit_uri_scheme_request_get_uri" :string
+  (request webkit-uri-scheme-request))
+(export 'webkit-uri-scheme-request-get-uri)
+
+(defcfun "webkit_uri_scheme_request_get_path" :string
+  (request webkit-uri-scheme-request))
+(export 'webkit-uri-scheme-request-get-path)
+
+(defcfun "webkit_uri_scheme_request_get_web-view" (g-object webkit-web-view)
+  (request webkit-uri-scheme-request))
+(export 'webkit-uri-scheme-request-get-web-view)
+
+(defcfun "webkit_uri_scheme_request_finish" :void
+  (request webkit-uri-scheme-request)
+  (stream :pointer)  ; XXX: GInputStream
+  (stream-length :int)
+  (contents :string))
+(export 'webkit-uri-scheme-request-finish)
+
+(defcfun ("webkit_uri_scheme_request_finish_error" %webkit-uri-scheme-request-finish-error) :void
+  (request webkit-uri-scheme-request)
+  (g-error :pointer))
+
+(defun webkit-uri-scheme-request-finish-error (request)
+  (glib:with-g-error (err)
+    (%webkit-uri-scheme-request-finish-error request err)))
+(export 'webkit-uri-scheme-request-finish-error)
+
+(cffi:defcallback uri-scheme-processed :void ((request :pointer) (user-data :pointer))
+  (let ((callback (find (cffi:pointer-address user-data) callbacks :key (function callback-id))))
+    (flet ((g-memory-input-stream-new-from-data (data-string)
+             (let* ((ffi-string (cffi:foreign-string-alloc data-string))
+                    ;; TODO: Can we rely on lisp's `length' here?
+                    ;; Will it give the same result as strlen on ffi-string?
+                    (ffi-string-length (length data-string))
+                    (stream (cffi:foreign-funcall "g_memory_input_stream_new_from_data"
+                                                  :string ffi-string
+                                                  :unsigned-int ffi-string-length
+                                                  ;; TODO: This should ideally be g_free()
+                                                  ;; to free the ffi-string automatically.
+                                                  :pointer (cffi:null-pointer))))
+               ;; ffi-string is returned because we need to free it afterwards
+               (values stream ffi-string ffi-string-length))))
+      (handler-case
+          (progn
+            (setf callbacks (delete callback callbacks))
+            ;; TODO: Use `unwind-protect' to free the allocated objects?
+            (when (callback-function callback)
+              (multiple-value-bind (data-type data)
+                  ;; Callback function should return data type (e.g., "text/html") as a first value
+                  ;; and data-string itself as a second value.
+                  (funcall (callback-function callback) request)
+                (multiple-value-bind (stream ffi-string data-length)
+                    (g-memory-input-stream-new-from-data data)
+                  (webkit-uri-scheme-request-finish request stream data-length data-type)
+                  (g:g-object-unref stream)
+                  ;; That's why g-memory-input-stream-new-from-data returns the string
+                  (cffi:foreign-string-free ffi-string)))))
+        (error (c)
+          (webkit-uri-scheme-request-finish-error request)
+          (when callback
+            (when (callback-error-function callback)
+              (funcall (callback-error-function callback) c))
+            (setf callbacks (delete callback callbacks))))))))
+
+(defun webkit-web-context-register-uri-scheme-callback (context scheme &optional call-back error-call-back)
+  (incf callback-counter)
+  (push (make-callback :id callback-counter :object context
+                       :function call-back
+                       :error-function error-call-back)
+        callbacks)
+  (webkit-web-context-register-uri-scheme
+   context scheme
+   (cffi:callback uri-scheme-processed)
+   (cffi:make-pointer callback-counter)
+   (cffi:null-pointer)))
+(export 'webkit-web-context-register-uri-scheme-callback)

--- a/webkit2/webkit2.uri-scheme-request.lisp
+++ b/webkit2/webkit2.uri-scheme-request.lisp
@@ -10,33 +10,33 @@
 
 (in-package #:webkit2)
 
-(defctype webkit-uri-scheme-request :pointer)
+(define-webkit-class "WebKitURISchemeRequest" () ())
 
 (defcfun "webkit_uri_scheme_request_get_scheme" :string
-  (request webkit-uri-scheme-request))
+  (request (g-object webkit-uri-scheme-request)))
 (export 'webkit-uri-scheme-request-get-scheme)
 
 (defcfun "webkit_uri_scheme_request_get_uri" :string
-  (request webkit-uri-scheme-request))
+  (request (g-object webkit-uri-scheme-request)))
 (export 'webkit-uri-scheme-request-get-uri)
 
 (defcfun "webkit_uri_scheme_request_get_path" :string
-  (request webkit-uri-scheme-request))
+  (request (g-object webkit-uri-scheme-request)))
 (export 'webkit-uri-scheme-request-get-path)
 
 (defcfun "webkit_uri_scheme_request_get_web-view" (g-object webkit-web-view)
-  (request webkit-uri-scheme-request))
+  (request (g-object webkit-uri-scheme-request)))
 (export 'webkit-uri-scheme-request-get-web-view)
 
 (defcfun "webkit_uri_scheme_request_finish" :void
-  (request webkit-uri-scheme-request)
+  (request (g-object webkit-uri-scheme-request))
   (stream :pointer)  ; XXX: GInputStream
   (stream-length :int)
   (contents :string))
 (export 'webkit-uri-scheme-request-finish)
 
 (defcfun ("webkit_uri_scheme_request_finish_error" %webkit-uri-scheme-request-finish-error) :void
-  (request webkit-uri-scheme-request)
+  (request (g-object webkit-uri-scheme-request))
   (g-error :pointer))
 
 (defun webkit-uri-scheme-request-finish-error (request error-string)

--- a/webkit2/webkit2.uri-scheme-request.lisp
+++ b/webkit2/webkit2.uri-scheme-request.lisp
@@ -71,7 +71,7 @@
                 (cffi:foreign-string-free ffi-string)))
           (error (c)
             (webkit-uri-scheme-request-finish-error
-             request (format nil "The custom url request for URI ~S failed with ~A: ~A"
+             request (format nil "The custom url request for URI ~a failed with ~a: ~a"
                              (webkit-uri-scheme-request-get-uri request) (type-of c) c))
             (when (and callback (callback-error-function callback))
               (funcall (callback-error-function callback) c))))))))

--- a/webkit2/webkit2.uri-scheme-request.lisp
+++ b/webkit2/webkit2.uri-scheme-request.lisp
@@ -103,7 +103,7 @@
 
 (defun webkit-web-context-register-uri-scheme-callback (context scheme &optional call-back error-call-back)
   (incf callback-counter)
-  (push (make-callback :id callback-counter :object context
+  (push (make-callback :id callback-counter :web-view context
                        :function call-back
                        :error-function error-call-back)
         callbacks)

--- a/webkit2/webkit2.web-view.lisp
+++ b/webkit2/webkit2.web-view.lisp
@@ -199,7 +199,7 @@
 (defvar callbacks ())
 (defstruct callback
   (id callback-counter :type number)
-  web-view
+  object
   (function nil :type (or function null))
   (error-function nil :type (or function null)))
 
@@ -208,7 +208,7 @@
   (declare (ignore source-object))
   (let ((callback (find (cffi:pointer-address user-data) callbacks :key (function callback-id))))
     (handler-case
-        (let* ((js-result (webkit-web-view-run-javascript-finish (callback-web-view callback) result))
+        (let* ((js-result (webkit-web-view-run-javascript-finish (callback-object callback) result))
                (context (webkit-javascript-result-get-global-context js-result))
                (value (webkit-javascript-result-get-value js-result))
                (js-str-value (jscore:js-value-to-string-copy context value (cffi:null-pointer)))
@@ -235,7 +235,7 @@
 (defun webkit-web-view-evaluate-javascript (web-view javascript &optional call-back error-call-back)
   "Evaluate JAVASCRIPT in WEB-VIEW calling CALL-BACK upon completion."
   (incf callback-counter)
-  (push (make-callback :id callback-counter :web-view web-view
+  (push (make-callback :id callback-counter :object web-view
                        :function call-back
                        :error-function error-call-back)
         callbacks)
@@ -277,7 +277,7 @@
 (defun webkit-web-view-evaluate-javascript-from-gresource (web-view resource &optional call-back error-call-back)
   "Evaluate JavaScript from RESOURCE in WEB-VIEW calling CALL-BACK upon completion and ERROR-CALL-BACK on error."
   (incf callback-counter)
-  (push (make-callback :id callback-counter :web-view web-view
+  (push (make-callback :id callback-counter :object web-view
                        :function call-back
                        :error-function error-call-back)
         callbacks)

--- a/webkit2/webkit2.web-view.lisp
+++ b/webkit2/webkit2.web-view.lisp
@@ -199,7 +199,7 @@
 (defvar callbacks ())
 (defstruct callback
   (id callback-counter :type number)
-  object
+  web-view
   (function nil :type (or function null))
   (error-function nil :type (or function null)))
 
@@ -208,7 +208,7 @@
   (declare (ignore source-object))
   (let ((callback (find (cffi:pointer-address user-data) callbacks :key (function callback-id))))
     (handler-case
-        (let* ((js-result (webkit-web-view-run-javascript-finish (callback-object callback) result))
+        (let* ((js-result (webkit-web-view-run-javascript-finish (callback-web-view callback) result))
                (context (webkit-javascript-result-get-global-context js-result))
                (value (webkit-javascript-result-get-value js-result))
                (js-str-value (jscore:js-value-to-string-copy context value (cffi:null-pointer)))
@@ -235,7 +235,7 @@
 (defun webkit-web-view-evaluate-javascript (web-view javascript &optional call-back error-call-back)
   "Evaluate JAVASCRIPT in WEB-VIEW calling CALL-BACK upon completion."
   (incf callback-counter)
-  (push (make-callback :id callback-counter :object web-view
+  (push (make-callback :id callback-counter :web-view web-view
                        :function call-back
                        :error-function error-call-back)
         callbacks)
@@ -277,7 +277,7 @@
 (defun webkit-web-view-evaluate-javascript-from-gresource (web-view resource &optional call-back error-call-back)
   "Evaluate JavaScript from RESOURCE in WEB-VIEW calling CALL-BACK upon completion and ERROR-CALL-BACK on error."
   (incf callback-counter)
-  (push (make-callback :id callback-counter :object web-view
+  (push (make-callback :id callback-counter :web-view web-view
                        :function call-back
                        :error-function error-call-back)
         callbacks)


### PR DESCRIPTION
This is a second attempt at #46. Reasons:
- I have accidentally deleted the fork :sweat_smile: 
- I've understood that `g_memory_input_stream_new_from_data` is the only `GInputStream` function that we need and it can be easily `flet`-bound.

# Things To Discuss
- Maybe binding `g_memory_input_stream_new_from_data` in `defcfun`? 
  + It's safer than `cffi:foreign-funcall`.
   - It can become irrelevant if `cl-cffi-gtk` gets `GInputStream` bindings, though.
- How do we enforce the multi-valued returns in callbacks? This change has too much implicit return values conventions... 
- `with-g-error` doesn't fit `webkit-uri-scheme-request-finish-error` because we need to create `GError` and pass it to this function, instead of getting the error from elsewhere (`with-g-error` is made for that). That's quite a quirky design that I'm uncertain about.

# How Has This Been Tested:

- See `custom-scheme-browser-main` in demo/simple-browser.lisp. 
  - It doesn't work yet, I'm trying to figure it out. That's a draft of how the scheme addition should look.

How does the new approach looks? 