### PR TITLE
Add full FindController bindings.

### DIFF
--- a/webkit2/webkit2.find-controller.lisp
+++ b/webkit2/webkit2.find-controller.lisp
@@ -28,6 +28,7 @@
   (search-text :string)
   (find-options :uint)
   (max-match-count :uint))
+(export 'webkit-find-controller-search)
 
 (defun webkit-find-controller-search* (controller search-text
                                        &key (max-match-count
@@ -63,7 +64,7 @@ Other keys regulate search. CASE-INSENSITIVE and WRAP-AROUND are set to true by 
         (cffi:foreign-enum-value 'webkit-find-options :webkit-find-options-wrap-around)
         0))
    max-match-count))
-(export 'webkit-find-controller-search)
+(export 'webkit-find-controller-search*)
 
 (defcfun "webkit_find_controller_search_next" :void
   (find-controller (g-object webkit-find-controller)))

--- a/webkit2/webkit2.find-controller.lisp
+++ b/webkit2/webkit2.find-controller.lisp
@@ -23,21 +23,21 @@
   (:webkit-find-options-backwards 8)
   (:webkit-find-options-wrap-around 16))
 
-(defcfun ("webkit_find_controller_search" %webkit-find-controller-search) :void
+(defcfun "webkit_find_controller_search" :void
   (find-controller (g-object webkit-find-controller))
   (search-text :string)
   (find-options :uint)
   (max-match-count :uint))
 
-(defun webkit-find-controller-search (controller search-text
-                                      &key (max-match-count
-                                            ;; I.e., UINT_MAX
-                                            (1- (expt 2 (* 8 (cffi:foreign-type-size :uint)))))
-                                        (case-insensitive t)
-                                        at-word-starts
-                                        treat-medial-capital-as-word-start
-                                        backwards
-                                        (wrap-around t))
+(defun webkit-find-controller-search* (controller search-text
+                                       &key (max-match-count
+                                             ;; I.e., UINT_MAX
+                                             (1- (expt 2 (* 8 (cffi:foreign-type-size :uint)))))
+                                         (case-insensitive t)
+                                         at-word-starts
+                                         treat-medial-capital-as-word-start
+                                         backwards
+                                         (wrap-around t))
   "A smarter version of webkit_find_controller_search with sensible defaults.
 CONTROLLER is a `webkit:webkit-find-controller'.
 SEARCH-TEXT is a string to search for.

--- a/webkit2/webkit2.find-controller.lisp
+++ b/webkit2/webkit2.find-controller.lisp
@@ -33,11 +33,11 @@
                                        &key (max-match-count
                                              ;; I.e., UINT_MAX
                                              (1- (expt 2 (* 8 (cffi:foreign-type-size :uint)))))
-                                         (case-insensitive t)
-                                         at-word-starts
-                                         treat-medial-capital-as-word-start
-                                         backwards
-                                         (wrap-around t))
+                                         (case-insensitive-p t)
+                                         at-word-starts-p
+                                         treat-medial-capital-as-word-start-p
+                                         backwards-p
+                                         (wrap-around-p t))
   "A smarter version of webkit_find_controller_search with sensible defaults.
 CONTROLLER is a `webkit:webkit-find-controller'.
 SEARCH-TEXT is a string to search for.
@@ -46,20 +46,20 @@ Other keys regulate search. CASE-INSENSITIVE and WRAP-AROUND are set to true by 
   (%webkit-find-controller-search
    controller search-text
    (logior
-    (if case-insensitive
+    (if case-insensitive-p
         (cffi:foreign-enum-value 'webkit-find-options :webkit-find-options-case-insensitive)
         0)
-    (if at-word-starts
+    (if at-word-starts-p
         (cffi:foreign-enum-value 'webkit-find-options :webkit-find-options-at-word-starts)
         0)
-    (if treat-medial-capital-as-word-start
+    (if treat-medial-capital-as-word-start-p
         (cffi:foreign-enum-value 'webkit-find-options
                                  :webkit-find-options-treat-medial-capital-as-word-start)
         0)
-    (if backwards
+    (if backwards-p
         (cffi:foreign-enum-value 'webkit-find-options :webkit-find-options-backwards)
         0)
-    (if wrap-around
+    (if wrap-around-p
         (cffi:foreign-enum-value 'webkit-find-options :webkit-find-options-wrap-around)
         0))
    max-match-count))

--- a/webkit2/webkit2.find-controller.lisp
+++ b/webkit2/webkit2.find-controller.lisp
@@ -15,11 +15,54 @@
    ("text" "gchararray")
    ("web-view" "WebKitWebView" t t)))
 
-(defcfun "webkit_find_controller_search" :void
+(define-g-enum "WebKitFindOptions" webkit-find-options ()
+  :webkit-find-options-none
+  (:webkit-find-options-case-insensitive 1)
+  (:webkit-find-options-at-word-starts 2)
+  (:webkit-find-options-treat-medial-capital-as-word-start 4)
+  (:webkit-find-options-backwards 8)
+  (:webkit-find-options-wrap-around 16))
+
+(defcfun ("webkit_find_controller_search" %webkit-find-controller-search) :void
   (find-controller (g-object webkit-find-controller))
   (search-text :string)
   (find-options :uint)
   (max-match-count :uint))
+
+(defun webkit-find-controller-search (controller search-text
+                                      &key (max-match-count
+                                            ;; I.e., UINT_MAX
+                                            (1- (expt 2 (* 8 (cffi:foreign-type-size :uint)))))
+                                        (case-insensitive t)
+                                        at-word-starts
+                                        treat-medial-capital-as-word-start
+                                        backwards
+                                        (wrap-around t))
+  "A smarter version of webkit_find_controller_search with sensible defaults.
+CONTROLLER is a `webkit:webkit-find-controller'.
+SEARCH-TEXT is a string to search for.
+MAX-MATCH-COUNT is the maximum match-count. Set to the max-match-count of CONTROLLER by default.
+Other keys regulate search. CASE-INSENSITIVE and WRAP-AROUND are set to true by default."
+  (%webkit-find-controller-search
+   controller search-text
+   (logior
+    (if case-insensitive
+        (cffi:foreign-enum-value 'webkit-find-options :webkit-find-options-case-insensitive)
+        0)
+    (if at-word-starts
+        (cffi:foreign-enum-value 'webkit-find-options :webkit-find-options-at-word-starts)
+        0)
+    (if treat-medial-capital-as-word-start
+        (cffi:foreign-enum-value 'webkit-find-options
+                                 :webkit-find-options-treat-medial-capital-as-word-start)
+        0)
+    (if backwards
+        (cffi:foreign-enum-value 'webkit-find-options :webkit-find-options-backwards)
+        0)
+    (if wrap-around
+        (cffi:foreign-enum-value 'webkit-find-options :webkit-find-options-wrap-around)
+        0))
+   max-match-count))
 (export 'webkit-find-controller-search)
 
 (defcfun "webkit_find_controller_search_next" :void


### PR DESCRIPTION
While not exactly strong, FindController is a reliable way to search a webpage. Even if we don't need it in Nyxt, so other software relying on `cl-webkit` could make use of it. Thus this addition.